### PR TITLE
improve language

### DIFF
--- a/getting-started-cloud-native.md
+++ b/getting-started-cloud-native.md
@@ -45,7 +45,7 @@ RHAMT examines application artifacts, including project source directories and a
 
 ---
 
-Red Hat Application Migration Toolkit looks for common resources and highlights technologies and known trouble spots when migrating applications. The goal is to provide a high-level view into the technologies used by the application and provide a detailed report organizations can use to estimate, document, and migrate enterprise applications to Java EE and Red Hat JBoss Enterprise Application Platform.
+Red Hat Application Migration Toolkit looks for common resources and highlights technologies and known trouble spots when migrating applications. The goal is to provide a high-level view into the technologies used by the application and provide a detailed report organizations can use to estimate, document, and carry out migration of enterprise applications to Java EE and Red Hat JBoss Enterprise Application Platform.
 
 > RHAMT is usually part of a much larger application migration and modernization program that involves well defined and repeatable phases over weeks or months and involves many people from a given business. Do not be fooled into thinking that every single
 migration is a simple affair and takes an hour or less! To learn more about Red Hat's philosophy and proven methodology, check out


### PR DESCRIPTION
Don't refer to 
https://access.redhat.com/documentation/en-us/red_hat_application_migration_toolkit/4.2/html-single/web_console_guide/index#about_rhamt

If you think that one should be updated too feel free to create a docs bug -- I'm reviewing the workshop guide and it's incorrect.