### PR TITLE
Fix a SQL injection issue in the example code.

### DIFF
--- a/break-monolith-apart2.md
+++ b/break-monolith-apart2.md
@@ -284,7 +284,7 @@ The _ProductRepositoryTest_ also used another method called _findById(String id)
 
 ~~~java
     public Product findById(String id) {
-        return this.jdbcTemplate.queryForObject("SELECT * FROM catalog WHERE itemId = '" + id + "'", rowMapper);
+        return this.jdbcTemplate.queryForObject("SELECT * FROM catalog WHERE itemId = ?", new Object[]{id}, rowMapper);
     }
 ~~~
 


### PR DESCRIPTION
The example code introduces a SQL-injection flaw into the application via string concatenation. This change replaces the call with one using a PreparedStatement to remove the flaw.